### PR TITLE
Add GitHub workflow to generate and publish docs

### DIFF
--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -1,0 +1,33 @@
+name: Generate docs
+
+on:
+  # Run when a release is published
+  release:
+    types:
+      - published
+
+jobs:
+  generate-docs:
+    name: Generate docs
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4.2.2
+      - name: Install Roc
+        uses: hasnep/setup-roc@v0.3.0
+        with:
+          roc-version: nightly
+      - name: Generate docs
+        run: roc docs src/main.roc
+      - name: Fix absolute paths
+        run: |
+          find generated-docs/ -type f -name '*.html' -exec sed -i "s/\(href\|src\)=\"\//\1=\"\/${{ github.event.repository.name }}\//g" {} +
+      - name: Upload docs artifact
+        uses: actions/upload-pages-artifact@v3.0.1
+        with:
+          path: generated-docs
+      - name: Deploy docs
+        uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
Addresses issue #1.

To deploy the docs to GitHub Pages, go to https://github.com/mulias/roc-array2d/settings/pages and change the source to GitHub Actions, then publish a new release of the package.